### PR TITLE
Use transport source term properly in compressible sim.

### DIFF
--- a/opm/polymer/SimulatorCompressiblePolymer.cpp
+++ b/opm/polymer/SimulatorCompressiblePolymer.cpp
@@ -318,8 +318,7 @@ namespace Opm
             }
 
             // Process transport sources (to include bdy terms and well flows).
-            Opm::computeTransportSource(grid_, src_, state.faceflux(), 1.0,
-                                        wells_, well_state.perfRates(), transport_src);
+            Opm::computeTransportSource(props_, wells_, well_state, transport_src);
 
             // Find inflow rate.
             const double current_time = timer.currentTime();
@@ -347,8 +346,7 @@ namespace Opm
                 double substep_polyinj = 0.0;
                 double substep_polyprod = 0.0;
                 Opm::computeInjectedProduced(props_, poly_props_,
-                                             state.pressure(), state.surfacevol(), state.saturation(),
-                                             state.concentration(), state.maxconcentration(),
+                                             state,
                                              transport_src, polymer_inflow_c, stepsize,
                                              substep_injected, substep_produced,
                                              substep_polyinj, substep_polyprod);

--- a/opm/polymer/SimulatorPolymer.cpp
+++ b/opm/polymer/SimulatorPolymer.cpp
@@ -337,7 +337,7 @@ namespace Opm
                 tsolver_.solve(&state.faceflux()[0], &porevol[0], &transport_src[0], &polymer_inflow_c[0], stepsize,
                                state.saturation(), state.concentration(), state.maxconcentration());
                 Opm::computeInjectedProduced(props_, poly_props_,
-                                             state.saturation(), state.concentration(), state.maxconcentration(),
+                                             state,
                                              transport_src, polymer_inflow_c, stepsize,
                                              substep_injected, substep_produced, substep_polyinj, substep_polyprod);
                 injected[0] += substep_injected[0];

--- a/opm/polymer/TransportModelCompressiblePolymer.cpp
+++ b/opm/polymer/TransportModelCompressiblePolymer.cpp
@@ -363,8 +363,7 @@ namespace Opm
         bool src_is_inflow = src_flux < 0.0;
         B_cell0 = 1.0/tm.A0_[np*np*cell + 0];
         B_cell = 1.0/tm.A_[np*np*cell + 0];
-        // influx  =  src_is_inflow ? B_cell*src_flux : 0.0; // Use this after changing transport source.
-        influx  =  src_is_inflow ? src_flux : 0.0;
+        influx  =  src_is_inflow ? B_cell*src_flux : 0.0;
         outflux = !src_is_inflow ? src_flux : 0.0;
         porevolume0 = tm.porevolume0_[cell];
         porevolume  = tm.porevolume_[cell];

--- a/opm/polymer/polymerUtilities.hpp
+++ b/opm/polymer/polymerUtilities.hpp
@@ -25,6 +25,7 @@
 #include <opm/core/fluid/IncompPropertiesInterface.hpp>
 #include <opm/core/fluid/BlackoilPropertiesInterface.hpp>
 #include <opm/polymer/PolymerProperties.hpp>
+#include <opm/polymer/PolymerState.hpp>
 #include <opm/polymer/PolymerBlackoilState.hpp>
 #include <opm/core/fluid/RockCompressibility.hpp>
 #include <opm/core/utility/SparseVector.hpp>
@@ -75,9 +76,9 @@ namespace Opm
     ///         gives the mobilities used for the preceding timestep.
     /// @param[in]  props     fluid and rock properties.
     /// @param[in]  polyprops polymer properties
-    /// @param[in]  s         saturation values (for all P phases)
-    /// @param[in]  c         polymer concentration
-    /// @param[in]  src       if < 0: total outflow, if > 0: first phase inflow.
+    /// @param[in]  state     state variables (pressure, fluxes etc.)
+    /// @param[in]  src       if < 0: total reservoir volume outflow,
+    ///                       if > 0: first phase reservoir volume inflow.
     /// @param[in]  inj_c     injected concentration by cell
     /// @param[in]  dt        timestep used
     /// @param[out] injected  must point to a valid array with P elements,
@@ -87,10 +88,8 @@ namespace Opm
     /// @param[out] polyprod  produced mass of polymer
     void computeInjectedProduced(const IncompPropertiesInterface& props,
                                  const Opm::PolymerProperties& polyprops,
-				 const std::vector<double>& s,
-				 const std::vector<double>& c,
-                                 const std::vector<double>& cmax,
-				 const std::vector<double>& src,
+                                 const PolymerState& state,
+				 const std::vector<double>& transport_src,
 				 const std::vector<double>& inj_c,
 				 const double dt,
 				 double* injected,
@@ -106,29 +105,20 @@ namespace Opm
     ///         gives the mobilities used for the preceding timestep.
     /// @param[in]  props     fluid and rock properties.
     /// @param[in]  polyprops polymer properties
-    /// @param[in]  press     pressure (one value per cell)
-    /// @param[in]  z         surface-volume values (for all P phases)
-    /// @param[in]  s         saturation values (for all P phases)
-    /// @param[in]  c         polymer concentration
-    /// @param[in]  cmax      polymer maximum concentration
-    /// @param[in]  src       if < 0: total outflow, if > 0: first phase inflow.
+    /// @param[in]  state     state variables (pressure, fluxes etc.)
+    /// @param[in]  src       if < 0: total reservoir volume outflow,
+    ///                       if > 0: first phase *surface volume* inflow.
     /// @param[in]  inj_c     injected concentration by cell
     /// @param[in]  dt        timestep used
-    ///
     /// @param[out] injected  must point to a valid array with P elements,
     ///                       where P = s.size()/src.size().
     /// @param[out] produced  must also point to a valid array with P elements.
     /// @param[out] polyinj   injected mass of polymer
     /// @param[out] polyprod  produced mass of polymer
-
     void computeInjectedProduced(const BlackoilPropertiesInterface& props,
                                  const Opm::PolymerProperties& polyprops,
-                                 const std::vector<double>& press,
-                                 const std::vector<double>& z,
-                                 const std::vector<double>& s,
-				 const std::vector<double>& c,
-				 const std::vector<double>& cmax,
-				 const std::vector<double>& src,
+                                 const PolymerBlackoilState& state,
+				 const std::vector<double>& transport_src,
 				 const std::vector<double>& inj_c,
 				 const double dt,
                                  double* injected,


### PR DESCRIPTION
This is similar to recent changes in opm-core.

Also fixed polymer mass balance report for multi-epoch case.
