### PR TITLE
Implement low-level init() routines

### DIFF
--- a/opm/polymer/PolymerBlackoilState.hpp
+++ b/opm/polymer/PolymerBlackoilState.hpp
@@ -35,9 +35,14 @@ namespace Opm
     public:
         void init(const UnstructuredGrid& g, int num_phases)
         {
-            state_blackoil_.init(g, num_phases);
-            concentration_.resize(g.number_of_cells, 0.0);
-            cmax_.resize(g.number_of_cells, 0.0);
+            this->init(g.number_of_cells, g.number_of_faces, num_phases);
+        }
+
+        void init(int number_of_cells, int number_of_faces, int num_phases)
+        {
+            state_blackoil_.init(number_of_cells, number_of_faces, num_phases);
+            concentration_.resize(number_of_cells, 0.0);
+            cmax_.resize(number_of_cells, 0.0);
         }
 
         enum ExtremalSat { MinSat = BlackoilState::MinSat, MaxSat = BlackoilState::MaxSat };

--- a/opm/polymer/PolymerState.hpp
+++ b/opm/polymer/PolymerState.hpp
@@ -34,9 +34,14 @@ namespace Opm
     public:
         void init(const UnstructuredGrid& g, int num_phases)
         {
-            state2p_.init(g, num_phases);
-            concentration_.resize(g.number_of_cells, 0.0);
-            cmax_.resize(g.number_of_cells, 0.0);
+            this->init(g.number_of_cells, g.number_of_faces, num_phases);
+        }
+
+        void init(int number_of_cells, int number_of_faces, int num_phases)
+        {
+            state2p_.init(number_of_cells, number_of_faces, num_phases);
+            concentration_.resize(number_of_cells, 0.0);
+            cmax_.resize(number_of_cells, 0.0);
         }
 
         enum ExtremalSat { MinSat = TwophaseState::MinSat, MaxSat = TwophaseState::MaxSat };


### PR DESCRIPTION
These are needed by the initialisation routines of the refactored opm-core (PR OPM/opm-core#518) that introduces support for parallel grids.
