### PR TITLE
use the TLMIXPAR keyword directly

### DIFF
--- a/examples/sim_poly2p_comp_reorder.cpp
+++ b/examples/sim_poly2p_comp_reorder.cpp
@@ -120,7 +120,7 @@ try
         }
         initBlackoilSurfvol(*grid->c_grid(), *props, state);
         // Init polymer properties.
-        poly_props.readFromDeck(eclipseState);
+        poly_props.readFromDeck(deck, eclipseState);
     } else {
         // Grid init.
         const int nx = param.getDefault("nx", 100);

--- a/examples/sim_poly2p_incomp_reorder.cpp
+++ b/examples/sim_poly2p_incomp_reorder.cpp
@@ -119,7 +119,7 @@ try
             initStateFromDeck(*grid->c_grid(), *props, deck, gravity[2], state);
         }
         // Init polymer properties.
-        poly_props.readFromDeck(eclipseState);
+        poly_props.readFromDeck(deck, eclipseState);
     } else {
         // Grid init.
         const int nx = param.getDefault("nx", 100);

--- a/opm/polymer/PolymerProperties.hpp
+++ b/opm/polymer/PolymerProperties.hpp
@@ -82,9 +82,9 @@ namespace Opm
         {
         }
 
-        PolymerProperties(Opm::EclipseStateConstPtr eclipseState)
+        PolymerProperties(Opm::DeckConstPtr deck, Opm::EclipseStateConstPtr eclipseState)
         {
-            readFromDeck(eclipseState);
+            readFromDeck(deck, eclipseState);
         }
 
         void set(double c_max,
@@ -117,18 +117,17 @@ namespace Opm
             shear_vrf_vals_ = shear_vrf_vals;
         }
 
-        void readFromDeck(Opm::EclipseStateConstPtr eclipseState)
+        void readFromDeck(Opm::DeckConstPtr deck, Opm::EclipseStateConstPtr eclipseState)
         {
             // We assume NTMISC=1
             const auto& plymaxTable = eclipseState->getPlymaxTables()[0];
-            const auto& tlmixparTable = eclipseState->getTlmixparTables()[0];
+            const auto tlmixparRecord = deck->getKeyword("TLMIXPAR")->getRecord(0);
 
             // We also assume that each table has exactly one row...
             assert(plymaxTable.numRows() == 1);
-            assert(tlmixparTable.numRows() == 1);
 
             c_max_ = plymaxTable.getPolymerConcentrationColumn()[0];
-            mix_param_ = tlmixparTable.getViscosityParameterColumn()[0];
+            mix_param_ = tlmixparRecord->getItem("TL_VISCOSITY_PARAMETER")->getSIDouble(0);
 
             // We assume NTSFUN=1
             const auto& plyrockTable = eclipseState->getPlyrockTables()[0];


### PR DESCRIPTION
instead of using a table class. This is because the keyword is not a
table...

this is required to fix after OPM/opm-parser#322 has been merged but it can be also merged before OPM/opm-parser#322. On my machine, everything compiles and all ctests pass...
