### PR TITLE
update packaging

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -20,7 +20,7 @@ override_dh_auto_build:
 
 # consider using -DUSE_VERSIONED_DIR=ON if backporting
 override_dh_auto_configure:
-	dh_auto_configure --buildsystem=cmake -- -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 -DCMAKE_INSTALL_DOCDIR=share/doc/libopm-polymer1 -DWHOLE_PROG_OPTIM=ON -DUSE_RUNPATH=OFF
+	dh_auto_configure --buildsystem=cmake -- -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 -DCMAKE_INSTALL_DOCDIR=share/doc/libopm-polymer1 -DWHOLE_PROG_OPTIM=OFF -DUSE_RUNPATH=OFF
 
 override_dh_auto_install:
 	dh_auto_install -- install-html


### PR DESCRIPTION
sorry for the extra pull but i couldn't check it earlier.

LTO fails with gcc 4.8. disable it.
