### PR TITLE
pass the deck to the output writer

### DIFF
--- a/examples/flow_polymer.cpp
+++ b/examples/flow_polymer.cpp
@@ -160,6 +160,7 @@ try
     const PhaseUsage pu = Opm::phaseUsageFromDeck(deck);
     Opm::BlackoilOutputWriter outputWriter(cGrid,
                                            param,
+                                           deck,
                                            eclipseState,
                                            pu );
 

--- a/examples/sim_poly_fi2p_comp_ad.cpp
+++ b/examples/sim_poly_fi2p_comp_ad.cpp
@@ -124,6 +124,7 @@ try
     auto &cGrid = *grid->c_grid();
     const PhaseUsage pu = Opm::phaseUsageFromDeck(deck);
     Opm::EclipseWriter outputWriter(param,
+                                    deck,
                                     eclipseState,
                                     pu,
                                     cGrid.number_of_cells,


### PR DESCRIPTION
this PR adapts to the EclipseWriter API change of OPM/opm-core#772 and must thus be merged synchronously.