### PR TITLE
Revert "pass the deck to the output writer"

### DIFF
--- a/examples/flow_polymer.cpp
+++ b/examples/flow_polymer.cpp
@@ -160,7 +160,6 @@ try
     const PhaseUsage pu = Opm::phaseUsageFromDeck(deck);
     Opm::BlackoilOutputWriter outputWriter(cGrid,
                                            param,
-                                           deck,
                                            eclipseState,
                                            pu );
 

--- a/examples/sim_poly_fi2p_comp_ad.cpp
+++ b/examples/sim_poly_fi2p_comp_ad.cpp
@@ -124,7 +124,6 @@ try
     auto &cGrid = *grid->c_grid();
     const PhaseUsage pu = Opm::phaseUsageFromDeck(deck);
     Opm::EclipseWriter outputWriter(param,
-                                    deck,
                                     eclipseState,
                                     pu,
                                     cGrid.number_of_cells,


### PR DESCRIPTION
This reverts commit 71987ae3b038c141a673ae1c1037f63ed695e595.

it is now required for OPM/opm-core#776