### PR TITLE
Adding startup message flow polymer and accpting single deck filename as command line argument.

### DIFF
--- a/examples/flow_polymer.cpp
+++ b/examples/flow_polymer.cpp
@@ -91,9 +91,18 @@ try
 {
     using namespace Opm;
 
-    std::cout << "\n================    Test program for fully implicit three-phase black-oil-polymer flow     ===============\n\n";
-    parameter::ParameterGroup param(argc, argv, false);
+    std::cout << "*********************************************************************************************\n";
+    std::cout << "*                                                                                           *\n";
+    std::cout << "*                       This is Flow-Polymer (version 2015.04)                              *\n";
+    std::cout << "*                                                                                           *\n";
+    std::cout << "* Flow-Polymer is a simulator for three-phase black-oil-polymer flow that is a part of OPM. *\n";
+    std::cout << "* For more information see:                                                                 *\n";
+    std::cout << "*                              http://opm-project.org                                       *\n";
+    std::cout << "*                                                                                           *\n";
+    std::cout << "*********************************************************************************************\n\n";
+
     std::cout << "---------------    Reading parameters     ---------------" << std::endl;
+    parameter::ParameterGroup param(argc, argv, false);
 
     // If we have a "deck_filename", grid and props will be read from that.
     bool use_deck = param.has("deck_filename");

--- a/examples/flow_polymer.cpp
+++ b/examples/flow_polymer.cpp
@@ -260,7 +260,7 @@ try
         if (use_wpolymer) {
             OPM_MESSAGE("Warning: use WPOLYMER in a non-polymer scenario.");
         }
-    }    
+    }
 
     bool use_local_perm = param.getDefault("use_local_perm", true);
     Opm::DerivedGeology geology(*grid->c_grid(), *new_props, eclipseState, use_local_perm, grav);

--- a/examples/flow_polymer.cpp
+++ b/examples/flow_polymer.cpp
@@ -101,15 +101,27 @@ try
     std::cout << "*                                                                                           *\n";
     std::cout << "*********************************************************************************************\n\n";
 
+    // Read parameters, see if a deck was specified on the command line.
     std::cout << "---------------    Reading parameters     ---------------" << std::endl;
     parameter::ParameterGroup param(argc, argv, false);
-
-    // If we have a "deck_filename", grid and props will be read from that.
-    bool use_deck = param.has("deck_filename");
-    if (!use_deck) {
-        OPM_THROW(std::runtime_error, "This program must be run with an input deck. "
-                  "Specify the deck with deck_filename=deckname.data (for example).");
+    if (!param.unhandledArguments().empty()) {
+        if (param.unhandledArguments().size() != 1) {
+            OPM_THROW(std::runtime_error, "You can only specify a single input deck on the command line.");
+        } else {
+            param.insertParameter("deck_filename", param.unhandledArguments()[0]);
+        }
     }
+
+    // We must have an input deck. Grid and props will be read from that.
+    if (!param.has("deck_filename")) {
+        std::cerr << "This program must be run with an input deck.\n"
+            "Specify the deck filename either\n"
+            "    a) as a command line argument by itself\n"
+            "    b) as a command line parameter with the syntax deck_filename=<path to your deck>, or\n"
+            "    c) as a parameter in a parameter file (.param or .xml) passed to the program.\n";
+        OPM_THROW(std::runtime_error, "Input deck required.");
+    }
+
     std::shared_ptr<GridManager> grid;
     std::shared_ptr<BlackoilPropertiesInterface> props;
     std::shared_ptr<BlackoilPropsAdFromDeck> new_props;


### PR DESCRIPTION
commit summary
1. Adding a start-up message similar to the nicer start-up message in PR OPM/opm-autodiff#355. The difference is that the message is 3 letter wider. 
2. Accept single deck filename as command line argument, same with PR OPM/opm-autodiff#356. The only difference is adding a linebreaker in the third option of how to specify a deck input. 
      As a result, the three methods to specify a deck file now are
          a) as a command line argument by itself
          b) as a command line parameter with the syntax deck_filename=<path to your deck>, or
          c) as a parameter in a parameter file (.param or .xml) passed to the program.
3. And removing a white space. 