### PR TITLE
Adapting some updates in opm-autodiff to opm-polymer. 

### DIFF
--- a/opm/polymer/fullyimplicit/FullyImplicitBlackoilPolymerSolver.hpp
+++ b/opm/polymer/fullyimplicit/FullyImplicitBlackoilPolymerSolver.hpp
@@ -296,10 +296,12 @@ namespace Opm {
         computeRelPerm(const SolutionState& state) const;
 
         void
-        computeMassFlux(const V&                transi,
-                        const std::vector<ADB>& kr    ,
-                        const std::vector<ADB>& phasePressure,
+        computeMassFlux(const int               actph ,
+                        const V&                transi,
+                        const ADB&              kr    ,
+                        const ADB&              p     ,
                         const SolutionState&    state );
+
         void
         computeCmax(PolymerBlackoilState& state);
 

--- a/opm/polymer/fullyimplicit/FullyImplicitBlackoilPolymerSolver.hpp
+++ b/opm/polymer/fullyimplicit/FullyImplicitBlackoilPolymerSolver.hpp
@@ -260,9 +260,7 @@ namespace Opm {
                   V& aliveWells,
                   const std::vector<double>& polymer_inflow);
 
-        void updateWellControls(ADB& bhp,
-                                ADB& well_phase_flow_rate,
-                                WellStateFullyImplicitBlackoil& xw) const;
+        void updateWellControls(WellStateFullyImplicitBlackoil& xw) const;
 
         void
         assemble(const V&             dtpv,

--- a/opm/polymer/fullyimplicit/FullyImplicitBlackoilPolymerSolver_impl.hpp
+++ b/opm/polymer/fullyimplicit/FullyImplicitBlackoilPolymerSolver_impl.hpp
@@ -584,21 +584,20 @@ namespace detail {
 
         // Pressure.
         int nextvar = 0;
-        state.pressure = vars[ nextvar++ ];
+        state.pressure = std::move(vars[ nextvar++ ]);
 
         // temperature
         const V temp = Eigen::Map<const V>(& x.temperature()[0], x.temperature().size());
         state.temperature = ADB::constant(temp);
 
         // Saturations
-        const std::vector<int>& bpat = vars[0].blockPattern();
         {
 
-            ADB so = ADB::constant(V::Ones(nc, 1), bpat);
+            ADB so = ADB::constant(V::Ones(nc, 1));
 
             if (active_[ Water ]) {
-                ADB& sw = vars[ nextvar++ ];
-                state.saturation[pu.phase_pos[ Water ]] = sw;
+                state.saturation[pu.phase_pos[ Water ]] = std::move(vars[ nextvar++ ]);
+                const ADB& sw = state.saturation[pu.phase_pos[ Water ]];
                 so -= sw;
             }
 
@@ -614,7 +613,7 @@ namespace detail {
                     // RS and RV is only defined if both oil and gas phase are active.
                     const ADB& sw = (active_[ Water ]
                                              ? state.saturation[ pu.phase_pos[ Water ] ]
-                                             : ADB::constant(V::Zero(nc, 1), bpat));
+                                             : ADB::constant(V::Zero(nc, 1)));
                     state.canonical_phase_pressures = computePressures(state.pressure, sw, so, sg);
                     const ADB rsSat = fluidRsSat(state.canonical_phase_pressures[ Oil ], so , cells_);
                     if (has_disgas_) {
@@ -633,20 +632,20 @@ namespace detail {
 
             if (active_[ Oil ]) {
                 // Note that so is never a primary variable.
-                state.saturation[pu.phase_pos[ Oil ]] = so;
+                state.saturation[pu.phase_pos[ Oil ]] = std::move(so);
             }
         }
 
         // Concentration.
         if (has_polymer_) {
-            state.concentration = vars[nextvar++];
+            state.concentration = std::move(vars[ nextvar++ ]);
         }
 
         // Qs.
-        state.qs = vars[ nextvar++ ];
+        state.qs = std::move(vars[ nextvar++ ]);
 
         // Bhp.
-        state.bhp = vars[ nextvar++ ];
+        state.bhp = std::move(vars[ nextvar++ ]);
 
         assert(nextvar == int(vars.size()));
 


### PR DESCRIPTION
Summary of the updates.

1.  variableState(), removing unused block patterns and using std::move.
2. computeMassFlux(), handling one phase each time. Polymer treatment is included as a part of the water phase, since whater phase will be affected by polymer. 
3. updateWellControls(), no longer update primary variables in the function and the function is moved to assemble()
4. addWellEq(), to match PR OPM/opm-autodiff#371.

The changes have been tested and verified with out current working DATA file. 