### PR TITLE
Restore build on older compilers

### DIFF
--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
@@ -51,7 +51,7 @@ namespace Opm {
         typedef typename Base::WellState WellState;
         // The next line requires C++11 support available in g++ 4.7.
         // friend Base;
-        friend BlackoilModelBase<Grid, BlackoilPolymerModel<Grid> >;
+        friend class BlackoilModelBase<Grid, BlackoilPolymerModel<Grid> >;
 
         /// Construct the model. It will retain references to the
         /// arguments of this functions, and they are expected to


### PR DESCRIPTION
Older compilers, e.g., GCC 4.4., do not understand the "simple-type-specifier" syntax of C++11's [`friend`](http://en.cppreference.com/w/cpp/language/friend) declarations. Typical responses are
```
error: a class-key must be used when declaring a friend
error: friend declaration does not name a class or function
```
Restore build on older compilers (e.g., GCC prior to 4.7) by inserting the `class` keyword.