### PR TITLE
Satisfy interface requirements of SimulatorBase.

### DIFF
--- a/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.hpp
+++ b/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.hpp
@@ -88,6 +88,9 @@ namespace Opm {
         int newtonIterations() const;
         int linearIterations() const;
 
+        /// Not used by this class except to satisfy interface requirements.
+        typedef parameter::ParameterGroup SolverParameters;
+
     private:
         typedef AutoDiffBlock<double> ADB;
         typedef ADB::V V;

--- a/opm/polymer/fullyimplicit/SimulatorFullyImplicitCompressiblePolymer.hpp
+++ b/opm/polymer/fullyimplicit/SimulatorFullyImplicitCompressiblePolymer.hpp
@@ -79,6 +79,11 @@ namespace Opm
         typedef BlackoilOutputWriter OutputWriter;
         typedef GridT Grid;
         typedef FullyImplicitCompressiblePolymerSolver Solver;
+        /// Dummy class, this Solver does not use a Model.
+        struct Model
+        {
+            typedef parameter::ParameterGroup ModelParameters;
+        };
     };
 
     /// Class collecting all necessary components for a two-phase simulation.


### PR DESCRIPTION
This is done with dummy types since the class in question (`SimulatorFullyImplicitCompressiblePolymer`) does not use a Model/Solver split.

With this, OPM/opm-autodiff#393 can be merged.