### PR TITLE
correcting the determination of out-of-table-range velocity

### DIFF
--- a/opm/polymer/PolymerProperties.cpp
+++ b/opm/polymer/PolymerProperties.cpp
@@ -505,7 +505,8 @@ namespace Opm
                     return false; // failed in finding the solution.
                 }
             } else {
-                if (std::abs(water_vel[i]) < maxShearVel) {
+                // check if the failure in finding the shear multiplier is due to too big water velocity.
+                if ((logWaterVelO - logShearVRF.back()) < logShearWaterVel.back()) {
                     std::cout << " the veclocity is " << water_vel[i] << std::endl;
                     std::cout << " max shear velocity is " << maxShearVel << std::endl;
                     std::cerr << " something wrong happend in finding segment" << std::endl;


### PR DESCRIPTION
A bug was discovered by some new examples. In the current master branch, we compared the obtained water velocity (shear rate) with the max velocity input in the `PLYSHLOG` table to see if the obtained water velocity is out of range of the range in the table. With some shear-thinning cases, even the water velocity is in the velocity range specified in the table, the shear-multiplier calculation still can be failed, when the sheared velocity (which is bigger than the pre-sheared water velocity) is out of velocity range input in the table. 

The suggested standard in this PR is more correct by comparing the sheared velocity with the maximum velocity input in the table to determine if the failure is due to the water velocity is too big to calculate the shear-multiplier. 

The PR is tested with a few working examples. 
