### PR TITLE
Restore build of flow_polymer

### DIFF
--- a/examples/flow_polymer.cpp
+++ b/examples/flow_polymer.cpp
@@ -268,7 +268,7 @@ try
     bool use_local_perm = param.getDefault("use_local_perm", true);
     Opm::DerivedGeology geology(*grid->c_grid(), *new_props, eclipseState, use_local_perm, grav);
 
-    std::vector<double> threshold_pressures = thresholdPressures(eclipseState, *grid->c_grid());
+    std::vector<double> threshold_pressures = thresholdPressures(parseMode, eclipseState, *grid->c_grid());
 
     SimulatorFullyImplicitBlackoilPolymer<UnstructuredGrid>
         simulator(param,


### PR DESCRIPTION
Function `Opm::thresholdPressures()` gained a new `ParseMode` parameter in commit OPM/opm-core@09aa2b7 (PR OPM/opm-core#857).  Chase updated call interface.