### PR TITLE
Update for opm-autodiff changes.

### DIFF
--- a/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.cpp
+++ b/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.cpp
@@ -664,18 +664,18 @@ namespace {
         M rate_distr(nw, np*nw);
         for (int w = 0; w < nw; ++w) {
             const WellControls* wc = wells_.ctrls[w];
-			if (well_controls_get_current_type(wc) == BHP) {
-				bhp_targets[w] = well_controls_get_current_target(wc);
+            if (well_controls_get_current_type(wc) == BHP) {
+                bhp_targets[w] = well_controls_get_current_target(wc);
                 rate_targets[w] = -1e100;
             } else if (well_controls_get_current_type(wc) == SURFACE_RATE) {
                 bhp_targets[w] = -1e100;
-				rate_targets[w] = well_controls_get_current_target(wc);
-				{	
-					const double* distr = well_controls_get_current_distr(wc);
+                rate_targets[w] = well_controls_get_current_target(wc);
+                {
+                    const double* distr = well_controls_get_current_distr(wc);
             	    for (int phase = 0; phase < np; ++phase) {
-                	    rate_distr.insert(w, phase*nw + w) = distr[phase];
-                	}
-				}
+                        rate_distr.insert(w, phase*nw + w) = distr[phase];
+                    }
+                }
             } else {
                 OPM_THROW(std::runtime_error, "Can only handle BHP and SURFACE_RATE type controls.");
             }

--- a/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.cpp
+++ b/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.cpp
@@ -81,7 +81,7 @@ namespace {
 
 
     template <class GeoProps>
-    AutoDiffBlock<double>::M
+    Eigen::SparseMatrix<double>
     gravityOperator(const UnstructuredGrid& grid,
                     const HelperOps&        ops ,
                     const GeoProps&         geo )
@@ -123,7 +123,8 @@ namespace {
             grav.push_back(Tri(i, c2, - t * dG2));
         }
 
-        M G(ni, nc);  G.setFromTriplets(grav.begin(), grav.end());
+        Eigen::SparseMatrix<double> G(ni, nc);
+        G.setFromTriplets(grav.begin(), grav.end());
 
         return G;
     }
@@ -661,7 +662,7 @@ namespace {
         // Handling BHP and SURFACE_RATE wells.
         V bhp_targets(nw);
         V rate_targets(nw);
-        M rate_distr(nw, np*nw);
+        Eigen::SparseMatrix<double> rate_distr(nw, np*nw);
         for (int w = 0; w < nw; ++w) {
             const WellControls* wc = wells_.ctrls[w];
             if (well_controls_get_current_type(wc) == BHP) {
@@ -981,7 +982,7 @@ namespace {
                 pm[i] = rock_comp_props_->poroMult(p.value()[i]);
                 dpm[i] = rock_comp_props_->poroMultDeriv(p.value()[i]);
             }
-            ADB::M dpm_diag = spdiag(dpm);
+            ADB::M dpm_diag(dpm.matrix().asDiagonal());
             const int num_blocks = p.numBlocks();
             std::vector<ADB::M> jacs(num_blocks);
             for (int block = 0; block < num_blocks; ++block) {
@@ -1008,7 +1009,7 @@ namespace {
                 tm[i] = rock_comp_props_->transMult(p.value()[i]);
                 dtm[i] = rock_comp_props_->transMultDeriv(p.value()[i]);
             }
-            ADB::M dtm_diag = spdiag(dtm);
+            ADB::M dtm_diag(dtm.matrix().asDiagonal());
             const int num_blocks = p.numBlocks();
             std::vector<ADB::M> jacs(num_blocks);
             for (int block = 0; block < num_blocks; ++block) {

--- a/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.hpp
+++ b/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.hpp
@@ -123,8 +123,8 @@ namespace Opm {
 
         struct WellOps {
             WellOps(const Wells& wells);
-            M w2p;              // well -> perf (scatter)
-            M p2w;              // perf -> well (gather)
+            Eigen::SparseMatrix<double> w2p;  // well -> perf (scatter)
+            Eigen::SparseMatrix<double> p2w;  // perf -> well (gather)
         };
 
         enum { Water = BlackoilPropsAdInterface::Water,

--- a/opm/polymer/fullyimplicit/PolymerPropsAd.cpp
+++ b/opm/polymer/fullyimplicit/PolymerPropsAd.cpp
@@ -179,7 +179,7 @@ namespace Opm {
     	    inv_mu_w_eff(i) = im;
     	    dinv_mu_w_eff(i) = dim;
     	}
-        ADB::M dim_diag = spdiag(dinv_mu_w_eff);
+        ADB::M dim_diag(dinv_mu_w_eff.matrix().asDiagonal());
         const int num_blocks = c.numBlocks();
         std::vector<ADB::M> jacs(num_blocks);
         for (int block = 0; block < num_blocks; ++block) {
@@ -226,7 +226,7 @@ namespace Opm {
             dmc(i) = dm;
         }
 
-        ADB::M dmc_diag = spdiag(dmc);
+        ADB::M dmc_diag(dmc.matrix().asDiagonal());
         const int num_blocks = c.numBlocks();
         std::vector<ADB::M> jacs(num_blocks);
         for (int block = 0; block < num_blocks; ++block) {
@@ -274,7 +274,7 @@ namespace Opm {
             dads(i) = dc_ads;
         }
 
-        ADB::M dads_diag = spdiag(dads);
+        ADB::M dads_diag(dads.matrix().asDiagonal());
         int num_blocks = c.numBlocks();
         std::vector<ADB::M> jacs(num_blocks);
         for (int block = 0; block < num_blocks; ++block) {


### PR DESCRIPTION
This makes the polymer simulators compile again, after OPM/opm-autodiff#456 was merged.