### PR TITLE
Refactor getConvergence()

### DIFF
--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
@@ -119,7 +119,7 @@ namespace Opm {
         /// residual mass balance (tol_cnv).
         /// \param[in]   dt          timestep length
         /// \param[in]   iteration   current iteration number
-        bool getConvergence(const double dt, const int iteration);
+        // bool getConvergence(const double dt, const int iteration);
 
         /// Assemble the residual and Jacobian of the nonlinear system.
         /// \param[in]      reservoir_state   reservoir state variables
@@ -275,16 +275,16 @@ namespace Opm {
         ///                   of B for the phase i.
         /// \param[in]  nc    The number of cells of the local grid.
         /// \return The total pore volume over all cells.
-        double
-        convergenceReduction(const Eigen::Array<double, Eigen::Dynamic, MaxNumPhases+1>& B,
-                             const Eigen::Array<double, Eigen::Dynamic, MaxNumPhases+1>& tempV,
-                             const Eigen::Array<double, Eigen::Dynamic, MaxNumPhases+1>& R,
-                             std::array<double,MaxNumPhases+1>& R_sum,
-                             std::array<double,MaxNumPhases+1>& maxCoeff,
-                             std::array<double,MaxNumPhases+1>& B_avg,
-                             std::vector<double>& maxNormWell,
-                             int nc,
-                             int nw) const;
+        // double
+        // convergenceReduction(const Eigen::Array<double, Eigen::Dynamic, MaxNumPhases+1>& B,
+        //                      const Eigen::Array<double, Eigen::Dynamic, MaxNumPhases+1>& tempV,
+        //                      const Eigen::Array<double, Eigen::Dynamic, MaxNumPhases+1>& R,
+        //                      std::array<double,MaxNumPhases+1>& R_sum,
+        //                      std::array<double,MaxNumPhases+1>& maxCoeff,
+        //                      std::array<double,MaxNumPhases+1>& B_avg,
+        //                      std::vector<double>& maxNormWell,
+        //                      int nc,
+        //                      int nw) const;
 
         /// Computing the water velocity without shear-thinning for the cell faces.
         /// The water velocity will be used for shear-thinning calculation.

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
@@ -115,12 +115,6 @@ namespace Opm {
                          ReservoirState& reservoir_state,
                          WellState& well_state);
 
-        /// Compute convergence based on total mass balance (tol_mb) and maximum
-        /// residual mass balance (tol_cnv).
-        /// \param[in]   dt          timestep length
-        /// \param[in]   iteration   current iteration number
-        // bool getConvergence(const double dt, const int iteration);
-
         /// Assemble the residual and Jacobian of the nonlinear system.
         /// \param[in]      reservoir_state   reservoir state variables
         /// \param[in, out] well_state        well state variables
@@ -255,36 +249,6 @@ namespace Opm {
 
         const std::vector<PhasePresence>
         phaseCondition() const {return this->phaseCondition_;}
-
-        /// \brief Compute the reduction within the convergence check.
-        /// \param[in] B     A matrix with MaxNumPhases columns and the same number rows
-        ///                  as the number of cells of the grid. B.col(i) contains the values
-        ///                  for phase i.
-        /// \param[in] tempV A matrix with MaxNumPhases columns and the same number rows
-        ///                  as the number of cells of the grid. tempV.col(i) contains the
-        ///                   values
-        ///                  for phase i.
-        /// \param[in] R     A matrix with MaxNumPhases columns and the same number rows
-        ///                  as the number of cells of the grid. B.col(i) contains the values
-        ///                  for phase i.
-        /// \param[out] R_sum An array of size MaxNumPhases where entry i contains the sum
-        ///                   of R for the phase i.
-        /// \param[out] maxCoeff An array of size MaxNumPhases where entry i contains the
-        ///                   maximum of tempV for the phase i.
-        /// \param[out] B_avg An array of size MaxNumPhases where entry i contains the average
-        ///                   of B for the phase i.
-        /// \param[in]  nc    The number of cells of the local grid.
-        /// \return The total pore volume over all cells.
-        // double
-        // convergenceReduction(const Eigen::Array<double, Eigen::Dynamic, MaxNumPhases+1>& B,
-        //                      const Eigen::Array<double, Eigen::Dynamic, MaxNumPhases+1>& tempV,
-        //                      const Eigen::Array<double, Eigen::Dynamic, MaxNumPhases+1>& R,
-        //                      std::array<double,MaxNumPhases+1>& R_sum,
-        //                      std::array<double,MaxNumPhases+1>& maxCoeff,
-        //                      std::array<double,MaxNumPhases+1>& B_avg,
-        //                      std::vector<double>& maxNormWell,
-        //                      int nc,
-        //                      int nw) const;
 
         /// Computing the water velocity without shear-thinning for the cell faces.
         /// The water velocity will be used for shear-thinning calculation.

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
@@ -110,6 +110,7 @@ namespace Opm {
             // If deck has polymer, residual_ should contain polymer equation.
             rq_.resize(fluid_.numPhases() + 1);
             residual_.material_balance_eq.resize(fluid_.numPhases() + 1, ADB::null());
+            Base::material_name_.push_back("Polymer");
             assert(poly_pos_ == fluid_.numPhases());
         }
     }
@@ -454,7 +455,7 @@ namespace Opm {
 
 
 
-
+    /*
     template <class Grid>
     double
     BlackoilPolymerModel<Grid>::convergenceReduction(const Eigen::Array<double, Eigen::Dynamic, MaxNumPhases+1>& B,
@@ -537,7 +538,7 @@ namespace Opm {
             return geo_.poreVolume().sum();
         }
     }
-
+    */
 
     template <class Grid>
     void
@@ -629,7 +630,7 @@ namespace Opm {
 
 
 
-
+    /*
     template <class Grid>
     bool
     BlackoilPolymerModel<Grid>::getConvergence(const double dt, const int iteration)
@@ -742,6 +743,7 @@ namespace Opm {
         }
         return converged;
     }
+    */
 
     template <class Grid>
     ADB

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
@@ -455,91 +455,6 @@ namespace Opm {
 
 
 
-    /*
-    template <class Grid>
-    double
-    BlackoilPolymerModel<Grid>::convergenceReduction(const Eigen::Array<double, Eigen::Dynamic, MaxNumPhases+1>& B,
-                                                     const Eigen::Array<double, Eigen::Dynamic, MaxNumPhases+1>& tempV,
-                                                     const Eigen::Array<double, Eigen::Dynamic, MaxNumPhases+1>& R,
-                                                     std::array<double,MaxNumPhases+1>& R_sum,
-                                                     std::array<double,MaxNumPhases+1>& maxCoeff,
-                                                     std::array<double,MaxNumPhases+1>& B_avg,
-                                                     std::vector<double>& maxNormWell,
-                                                     int nc,
-                                                     int nw) const
-    {
-        // Do the global reductions
-#if HAVE_MPI
-        if ( linsolver_.parallelInformation().type() == typeid(ParallelISTLInformation) )
-        {
-            const ParallelISTLInformation& info =
-                boost::any_cast<const ParallelISTLInformation&>(linsolver_.parallelInformation());
-
-            // Compute the global number of cells and porevolume
-            std::vector<int> v(nc, 1);
-            auto nc_and_pv = std::tuple<int, double>(0, 0.0);
-            auto nc_and_pv_operators = std::make_tuple(Opm::Reduction::makeGlobalSumFunctor<int>(),
-                                                        Opm::Reduction::makeGlobalSumFunctor<double>());
-            auto nc_and_pv_containers  = std::make_tuple(v, geo_.poreVolume());
-            info.computeReduction(nc_and_pv_containers, nc_and_pv_operators, nc_and_pv);
-
-            for ( int idx=0; idx<MaxNumPhases+1; ++idx )
-            {
-                if ((idx == MaxNumPhases && has_polymer_) || active_[idx]) { // Dealing with polymer *or* an active phase.
-                    auto values     = std::tuple<double,double,double>(0.0 ,0.0 ,0.0);
-                    auto containers = std::make_tuple(B.col(idx),
-                                                      tempV.col(idx),
-                                                      R.col(idx));
-                    auto operators  = std::make_tuple(Opm::Reduction::makeGlobalSumFunctor<double>(),
-                                                      Opm::Reduction::makeGlobalMaxFunctor<double>(),
-                                                      Opm::Reduction::makeGlobalSumFunctor<double>());
-                    info.computeReduction(containers, operators, values);
-                    B_avg[idx]       = std::get<0>(values)/std::get<0>(nc_and_pv);
-                    maxCoeff[idx]    = std::get<1>(values);
-                    R_sum[idx]       = std::get<2>(values);
-                    if (idx != MaxNumPhases) { // We do not compute a well flux residual for polymer.
-                        maxNormWell[idx] = 0.0;
-                        for ( int w=0; w<nw; ++w ) {
-                            maxNormWell[idx]  = std::max(maxNormWell[idx], std::abs(residual_.well_flux_eq.value()[nw*idx + w]));
-                        }
-                    }
-                }
-                else
-                {
-                    maxNormWell[idx] = R_sum[idx] = B_avg[idx] = maxCoeff[idx] = 0.0;
-                }
-            }
-            info.communicator().max(&maxNormWell[0], MaxNumPhases+1);
-            // Compute pore volume
-            return std::get<1>(nc_and_pv);
-        }
-        else
-#endif
-        {
-            for ( int idx=0; idx<MaxNumPhases+1; ++idx )
-            {
-                if ((idx == MaxNumPhases && has_polymer_) || active_[idx]) { // Dealing with polymer *or* an active phase.
-                    B_avg[idx] = B.col(idx).sum()/nc;
-                    maxCoeff[idx] = tempV.col(idx).maxCoeff();
-                    R_sum[idx] = R.col(idx).sum();
-                }
-                else
-                {
-                    R_sum[idx] = B_avg[idx] = maxCoeff[idx] =0.0;
-                }
-                if (idx != MaxNumPhases) { // We do not compute a well flux residual for polymer.
-                    maxNormWell[idx] = 0.0;
-                    for ( int w=0; w<nw; ++w ) {
-                        maxNormWell[idx]  = std::max(maxNormWell[idx], std::abs(residual_.well_flux_eq.value()[nw*idx + w]));
-                    }
-                }
-            }
-            // Compute total pore volume
-            return geo_.poreVolume().sum();
-        }
-    }
-    */
-
     template <class Grid>
     void
     BlackoilPolymerModel<Grid>::assemble(const ReservoirState& reservoir_state,
@@ -630,120 +545,6 @@ namespace Opm {
 
 
 
-    /*
-    template <class Grid>
-    bool
-    BlackoilPolymerModel<Grid>::getConvergence(const double dt, const int iteration)
-    {
-        const double tol_mb    = param_.tolerance_mb_;
-        const double tol_cnv   = param_.tolerance_cnv_;
-        const double tol_wells = param_.tolerance_wells_;
-
-        const int nc = Opm::AutoDiffGrid::numCells(grid_);
-        const int nw = wellsActive() ? wells().number_of_wells : 0;
-        const Opm::PhaseUsage& pu = fluid_.phaseUsage();
-
-        const V pv = geo_.poreVolume();
-
-        const std::vector<PhasePresence> cond = phaseCondition();
-
-        std::array<double,MaxNumPhases+1> CNV                   = {{0., 0., 0., 0.}};
-        std::array<double,MaxNumPhases+1> R_sum                 = {{0., 0., 0., 0.}};
-        std::array<double,MaxNumPhases+1> B_avg                 = {{0., 0., 0., 0.}};
-        std::array<double,MaxNumPhases+1> maxCoeff              = {{0., 0., 0., 0.}};
-        std::array<double,MaxNumPhases+1> mass_balance_residual = {{0., 0., 0., 0.}};
-        std::array<double,MaxNumPhases> well_flux_residual    = {{0., 0., 0.}};
-        std::size_t cols = MaxNumPhases+1; // needed to pass the correct type to Eigen
-        Eigen::Array<V::Scalar, Eigen::Dynamic, MaxNumPhases+1> B(nc, cols);
-        Eigen::Array<V::Scalar, Eigen::Dynamic, MaxNumPhases+1> R(nc, cols);
-        Eigen::Array<V::Scalar, Eigen::Dynamic, MaxNumPhases+1> tempV(nc, cols);
-        std::vector<double> maxNormWell(MaxNumPhases);
-
-        for ( int idx=0; idx<MaxNumPhases; ++idx )
-        {
-            if (active_[idx]) {
-                const int pos    = pu.phase_pos[idx];
-                const ADB& tempB = rq_[pos].b;
-                B.col(idx)       = 1./tempB.value();
-                R.col(idx)       = residual_.material_balance_eq[idx].value();
-                tempV.col(idx)   = R.col(idx).abs()/pv;
-            }
-        }
-        if (has_polymer_) {
-            const ADB& tempB = rq_[poly_pos_].b;
-            B.col(MaxNumPhases) = 1. / tempB.value();
-            R.col(MaxNumPhases) = residual_.material_balance_eq[poly_pos_].value();
-            tempV.col(MaxNumPhases) = R.col(MaxNumPhases).abs()/pv;
-        }
-
-        const double pvSum = convergenceReduction(B, tempV, R, R_sum, maxCoeff, B_avg,
-                                                  maxNormWell, nc, nw);
-
-        bool converged_MB = true;
-        bool converged_CNV = true;
-        bool converged_Well = true;
-        // Finish computation
-        for ( int idx=0; idx<MaxNumPhases+1; ++idx )
-        {
-            CNV[idx]                   = B_avg[idx] * dt * maxCoeff[idx];
-            mass_balance_residual[idx] = std::abs(B_avg[idx]*R_sum[idx]) * dt / pvSum;
-            converged_MB               = converged_MB && (mass_balance_residual[idx] < tol_mb);
-            converged_CNV              = converged_CNV && (CNV[idx] < tol_cnv);
-            if (idx != MaxNumPhases) { // No well flux residual for polymer.
-                well_flux_residual[idx]    = B_avg[idx] * dt * maxNormWell[idx];
-                converged_Well = converged_Well && (well_flux_residual[idx] < tol_wells);
-            }
-        }
-
-        const double residualWell     = detail::infinityNormWell(residual_.well_eq,
-                                                                 linsolver_.parallelInformation());
-        converged_Well   = converged_Well && (residualWell < Opm::unit::barsa);
-        const bool   converged        = converged_MB && converged_CNV && converged_Well;
-
-        // if one of the residuals is NaN, throw exception, so that the solver can be restarted
-        if (std::isnan(mass_balance_residual[Water]) || mass_balance_residual[Water] > maxResidualAllowed() ||
-            std::isnan(mass_balance_residual[Oil])   || mass_balance_residual[Oil]   > maxResidualAllowed() ||
-            std::isnan(mass_balance_residual[Gas])   || mass_balance_residual[Gas]   > maxResidualAllowed() ||
-            std::isnan(mass_balance_residual[MaxNumPhases])   || mass_balance_residual[MaxNumPhases]   > maxResidualAllowed() ||
-            std::isnan(CNV[Water]) || CNV[Water] > maxResidualAllowed() ||
-            std::isnan(CNV[Oil]) || CNV[Oil] > maxResidualAllowed() ||
-            std::isnan(CNV[Gas]) || CNV[Gas] > maxResidualAllowed() ||
-            std::isnan(CNV[MaxNumPhases]) || CNV[MaxNumPhases] > maxResidualAllowed() ||
-            std::isnan(well_flux_residual[Water]) || well_flux_residual[Water] > maxResidualAllowed() ||
-            std::isnan(well_flux_residual[Oil]) || well_flux_residual[Oil] > maxResidualAllowed() ||
-            std::isnan(well_flux_residual[Gas]) || well_flux_residual[Gas] > maxResidualAllowed() ||
-            std::isnan(residualWell)     || residualWell     > maxResidualAllowed() )
-        {
-            OPM_THROW(Opm::NumericalProblem,"One of the residuals is NaN or too large!");
-        }
-
-        if ( terminal_output_ )
-        {
-            // Only rank 0 does print to std::cout
-            if (iteration == 0) {
-                std::cout << "\nIter  MB(WATER)   MB(OIL)    MB(GAS)    MB(POLY)      CNVW       CNVO       CNVG       CNVP   W-FLUX(W)  W-FLUX(O)  W-FLUX(G)\n";
-            }
-            const std::streamsize oprec = std::cout.precision(3);
-            const std::ios::fmtflags oflags = std::cout.setf(std::ios::scientific);
-            std::cout << std::setw(4) << iteration
-                      << std::setw(11) << mass_balance_residual[Water]
-                      << std::setw(11) << mass_balance_residual[Oil]
-                      << std::setw(11) << mass_balance_residual[Gas]
-                      << std::setw(11) << mass_balance_residual[MaxNumPhases]
-                      << std::setw(11) << CNV[Water]
-                      << std::setw(11) << CNV[Oil]
-                      << std::setw(11) << CNV[Gas]
-                      << std::setw(11) << CNV[MaxNumPhases]
-                      << std::setw(11) << well_flux_residual[Water]
-                      << std::setw(11) << well_flux_residual[Oil]
-                      << std::setw(11) << well_flux_residual[Gas]
-                      << std::endl;
-            std::cout.precision(oprec);
-            std::cout.flags(oflags);
-        }
-        return converged;
-    }
-    */
 
     template <class Grid>
     ADB
@@ -751,6 +552,9 @@ namespace Opm {
     {
         return polymer_props_ad_.polymerWaterVelocityRatio(state.concentration);
     }
+
+
+
 
     template<class Grid>
     void
@@ -865,6 +669,9 @@ namespace Opm {
         }
 
     }
+
+
+
 
     template<class Grid>
     void


### PR DESCRIPTION
With the changes in OPM/opm-autodiff#492, the custom getConvergence() and convergenceReduction() methods are no longer required and can be deleted.

Also, we add the material name "Polymer" so that reporting works properly.

Edit: this has been tested with a simple polymer test case, and gives slightly different results from the master branch. However this is because the master branch did not incorporate a change made in opm-autodiff in June (no longer scaling the well flux residual with dt for convergence tests). With this PR, they will use the same implementation and not get out of sync like that