### PR TITLE
use the error macros from opm-common

### DIFF
--- a/examples/flow_polymer.cpp
+++ b/examples/flow_polymer.cpp
@@ -25,7 +25,7 @@
 #include <opm/core/grid/GridManager.hpp>
 #include <opm/core/wells.h>
 #include <opm/core/wells/WellsManager.hpp>
-#include <opm/core/utility/ErrorMacros.hpp>
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/core/simulator/initState.hpp>
 #include <opm/core/simulator/initStateEquil.hpp>
 #include <opm/core/simulator/SimulatorReport.hpp>

--- a/examples/sim_poly2p_comp_reorder.cpp
+++ b/examples/sim_poly2p_comp_reorder.cpp
@@ -28,7 +28,7 @@
 #include <opm/core/grid/GridManager.hpp>
 #include <opm/core/wells.h>
 #include <opm/core/wells/WellsManager.hpp>
-#include <opm/core/utility/ErrorMacros.hpp>
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/core/simulator/initState.hpp>
 #include <opm/core/simulator/SimulatorReport.hpp>
 #include <opm/core/simulator/SimulatorTimer.hpp>

--- a/examples/sim_poly2p_incomp_reorder.cpp
+++ b/examples/sim_poly2p_incomp_reorder.cpp
@@ -28,7 +28,7 @@
 #include <opm/core/grid/GridManager.hpp>
 #include <opm/core/wells.h>
 #include <opm/core/wells/WellsManager.hpp>
-#include <opm/core/utility/ErrorMacros.hpp>
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/core/simulator/initState.hpp>
 #include <opm/core/simulator/SimulatorReport.hpp>
 #include <opm/core/simulator/SimulatorTimer.hpp>

--- a/examples/sim_poly_fi2p_comp_ad.cpp
+++ b/examples/sim_poly_fi2p_comp_ad.cpp
@@ -29,7 +29,7 @@
 #include <opm/core/grid/GridManager.hpp>
 #include <opm/core/wells.h>
 #include <opm/core/wells/WellsManager.hpp>
-#include <opm/core/utility/ErrorMacros.hpp>
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/core/simulator/initState.hpp>
 #include <opm/core/simulator/SimulatorReport.hpp>
 #include <opm/core/simulator/SimulatorTimer.hpp>

--- a/examples/test_singlecellsolves.cpp
+++ b/examples/test_singlecellsolves.cpp
@@ -28,7 +28,7 @@
 #include <opm/core/grid/GridManager.hpp>
 #include <opm/core/wells.h>
 #include <opm/core/wells/WellsManager.hpp>
-#include <opm/core/utility/ErrorMacros.hpp>
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/core/simulator/initState.hpp>
 #include <opm/core/simulator/SimulatorReport.hpp>
 #include <opm/core/simulator/SimulatorTimer.hpp>

--- a/opm/polymer/CompressibleTpfaPolymer.cpp
+++ b/opm/polymer/CompressibleTpfaPolymer.cpp
@@ -31,7 +31,7 @@
 #include <opm/core/linalg/sparse_sys.h>
 #include <opm/polymer/polymerUtilities.hpp>
 #include <opm/core/simulator/WellState.hpp>
-#include <opm/core/utility/ErrorMacros.hpp>
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/core/utility/miscUtilities.hpp>
 #include <opm/core/wells.h>
 #include <iomanip>

--- a/opm/polymer/GravityColumnSolverPolymer_impl.hpp
+++ b/opm/polymer/GravityColumnSolverPolymer_impl.hpp
@@ -38,7 +38,7 @@
 
 #include <opm/polymer/GravityColumnSolverPolymer.hpp>
 #include <opm/core/linalg/blas_lapack.h>
-#include <opm/core/utility/ErrorMacros.hpp>
+#include <opm/common/ErrorMacros.hpp>
 #include <iterator>
 #include <iostream>
 #include <cmath>

--- a/opm/polymer/IncompPropertiesDefaultPolymer.hpp
+++ b/opm/polymer/IncompPropertiesDefaultPolymer.hpp
@@ -22,7 +22,7 @@
 
 #include <opm/core/props/IncompPropertiesBasic.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
-#include <opm/core/utility/ErrorMacros.hpp>
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/core/utility/linearInterpolation.hpp>
 #include <vector>
 

--- a/opm/polymer/IncompTpfaPolymer.cpp
+++ b/opm/polymer/IncompTpfaPolymer.cpp
@@ -33,7 +33,7 @@
 #include <opm/polymer/PolymerState.hpp>
 #include <opm/polymer/polymerUtilities.hpp>
 #include <opm/core/simulator/WellState.hpp>
-#include <opm/core/utility/ErrorMacros.hpp>
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/core/utility/miscUtilities.hpp>
 #include <opm/core/wells.h>
 #include <iomanip>

--- a/opm/polymer/PolymerProperties.cpp
+++ b/opm/polymer/PolymerProperties.cpp
@@ -24,8 +24,8 @@
 #include <cmath>
 #include <vector>
 #include <opm/core/utility/linearInterpolation.hpp>
-#include <opm/core/utility/ErrorMacros.hpp>
-#include <opm/core/utility/Exceptions.hpp>
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/common/Exceptions.hpp>
 
 namespace Opm
 {

--- a/opm/polymer/PolymerProperties.hpp
+++ b/opm/polymer/PolymerProperties.hpp
@@ -25,7 +25,7 @@
 
 #include <cmath>
 #include <vector>
-#include <opm/core/utility/ErrorMacros.hpp>
+#include <opm/common/ErrorMacros.hpp>
 
 
 namespace Opm

--- a/opm/polymer/SimulatorCompressiblePolymer.cpp
+++ b/opm/polymer/SimulatorCompressiblePolymer.cpp
@@ -23,7 +23,7 @@
 
 #include <opm/polymer/SimulatorCompressiblePolymer.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
-#include <opm/core/utility/ErrorMacros.hpp>
+#include <opm/common/ErrorMacros.hpp>
 
 #include <opm/polymer/CompressibleTpfaPolymer.hpp>
 

--- a/opm/polymer/SimulatorPolymer.cpp
+++ b/opm/polymer/SimulatorPolymer.cpp
@@ -24,7 +24,7 @@
 
 #include <opm/polymer/SimulatorPolymer.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
-#include <opm/core/utility/ErrorMacros.hpp>
+#include <opm/common/ErrorMacros.hpp>
 
 #include <opm/polymer/IncompTpfaPolymer.hpp>
 

--- a/opm/polymer/TransportSolverTwophaseCompressiblePolymer.cpp
+++ b/opm/polymer/TransportSolverTwophaseCompressiblePolymer.cpp
@@ -27,7 +27,7 @@
 #include <opm/core/utility/miscUtilities.hpp>
 #include <opm/core/utility/miscUtilitiesBlackoil.hpp>
 #include <opm/core/pressure/tpfa/trans_tpfa.h>
-#include <opm/core/utility/ErrorMacros.hpp>
+#include <opm/common/ErrorMacros.hpp>
 #include <cmath>
 #include <list>
 #include <iostream>

--- a/opm/polymer/TransportSolverTwophasePolymer.cpp
+++ b/opm/polymer/TransportSolverTwophasePolymer.cpp
@@ -26,7 +26,7 @@
 #include <opm/core/utility/RootFinders.hpp>
 #include <opm/core/utility/miscUtilities.hpp>
 #include <opm/core/pressure/tpfa/trans_tpfa.h>
-#include <opm/core/utility/ErrorMacros.hpp>
+#include <opm/common/ErrorMacros.hpp>
 #include <cmath>
 #include <list>
 #include <iostream>

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
@@ -37,8 +37,8 @@
 #include <opm/core/linalg/LinearSolverInterface.hpp>
 #include <opm/core/linalg/ParallelIstlInformation.hpp>
 #include <opm/core/props/rock/RockCompressibility.hpp>
-#include <opm/core/utility/ErrorMacros.hpp>
-#include <opm/core/utility/Exceptions.hpp>
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/common/Exceptions.hpp>
 #include <opm/core/utility/Units.hpp>
 #include <opm/core/well_controls.h>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>

--- a/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.cpp
+++ b/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.cpp
@@ -33,7 +33,7 @@
 #include <opm/core/linalg/LinearSolverInterface.hpp>
 #include <opm/core/props/rock/RockCompressibility.hpp>
 #include <opm/polymer/PolymerBlackoilState.hpp>
-#include <opm/core/utility/ErrorMacros.hpp>
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/core/well_controls.h>
 #include <cassert>
 #include <cmath>

--- a/opm/polymer/fullyimplicit/SimulatorFullyImplicitBlackoilPolymer.hpp
+++ b/opm/polymer/fullyimplicit/SimulatorFullyImplicitBlackoilPolymer.hpp
@@ -29,7 +29,7 @@
 #include <opm/polymer/PolymerInflow.hpp>
 
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
-#include <opm/core/utility/ErrorMacros.hpp>
+#include <opm/common/ErrorMacros.hpp>
 
 #include <opm/autodiff/GeoProps.hpp>
 #include <opm/autodiff/BlackoilPropsAdInterface.hpp>

--- a/opm/polymer/fullyimplicit/SimulatorFullyImplicitCompressiblePolymer.hpp
+++ b/opm/polymer/fullyimplicit/SimulatorFullyImplicitCompressiblePolymer.hpp
@@ -22,7 +22,7 @@
 #define OPM_SIMULATORFULLYIMPLICITCOMPRESSIBLEPOLYMER_HEADER_INCLUDED
 
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
-#include <opm/core/utility/ErrorMacros.hpp>
+#include <opm/common/ErrorMacros.hpp>
 
 #include <opm/autodiff/GeoProps.hpp>
 #include <opm/autodiff/BlackoilPropsAdInterface.hpp>


### PR DESCRIPTION
this makes the polymer module compile again after the error macros have been moved to opm-common. It seems like I forgot to open a PR for the polymer module when doing OPM/opm-common#55. sorry for the hiccup.