### PR TITLE
adapt to the threshold pressure related API changes

### DIFF
--- a/examples/flow_polymer.cpp
+++ b/examples/flow_polymer.cpp
@@ -127,7 +127,7 @@ try
     }
 
     std::shared_ptr<GridManager> grid;
-    std::shared_ptr<BlackoilPropertiesInterface> props;
+    std::shared_ptr<BlackoilPropertiesFromDeck> props;
     std::shared_ptr<BlackoilPropsAdFromDeck> new_props;
     std::shared_ptr<RockCompressibility> rock_comp;
     PolymerBlackoilState state;
@@ -279,7 +279,9 @@ try
     bool use_local_perm = param.getDefault("use_local_perm", true);
     Opm::DerivedGeology geology(*grid->c_grid(), *new_props, eclipseState, use_local_perm, grav);
 
-    std::vector<double> threshold_pressures = thresholdPressures(parseMode, eclipseState, *grid->c_grid());
+    std::map<std::pair<int, int>, double> maxDp;
+    computeMaxDp(maxDp, deck, eclipseState, *grid->c_grid(), state, *props, gravity[2]);
+    std::vector<double> threshold_pressures = thresholdPressures(deck, eclipseState, *grid->c_grid(), maxDp);
 
     Opm::BlackoilOutputWriter
         outputWriter(cGrid, param, eclipseState, pu,


### PR DESCRIPTION
to be able to determine the threshold pressure from the initial
condition it needs to be able to access the initial condition, i.e.,
the initial simulator state, material properties object and gravity
constant need to be passed to the thresholdPressure() function.

this is a follow-up of OPM/opm-core#907.