### PR TITLE
Bump version and unify format of dune.module.

### DIFF
--- a/dune.module
+++ b/dune.module
@@ -1,6 +1,13 @@
+####################################################################
+# Dune module information file: This file gets parsed by dunecontrol
+# and by the CMake build scripts.
+####################################################################
+
 Module: opm-polymer
 Description: OPM module for polymer simulations
-Version: 1.0.1
-Label: 2013.10
+Version: 2016.04-pre
+Label: 2016.04-pre
 Maintainer: atgeirr@sintef.no
+MaintainerName: Atgeirr F. Rasmussen
+Url: http://opm-project.org
 Depends: opm-common opm-autodiff


### PR DESCRIPTION
After this, all code modules have the same formatting in dune.module, and the correct version name (for the master branch): "2016.04-pre".